### PR TITLE
fix: Sub-Phase 3.1.5 レビュー指摘対応

### DIFF
--- a/jquants/client_v2.py
+++ b/jquants/client_v2.py
@@ -4,6 +4,7 @@ import json
 import os
 import platform
 import sys
+import time
 import tomllib
 import warnings
 from pathlib import Path
@@ -230,18 +231,19 @@ class ClientV2:
         Note:
             POST is excluded from allowed_methods to prevent
             duplicate side effects on retry.
+            429 is excluded from status_forcelist to use custom retry logic.
         """
         if self._session is None:
             retry_strategy = Retry(
                 total=3,
-                status_forcelist=[429, 500, 502, 503, 504],
+                status_forcelist=[500, 502, 503, 504],  # 429 excluded for custom retry
                 allowed_methods=["HEAD", "GET", "OPTIONS"],  # POST excluded
                 backoff_factor=0.5,  # Retry-After無しの場合のbackoff
                 respect_retry_after_header=True,
             )
             adapter = HTTPAdapter(
-                pool_connections=self.MAX_WORKERS + 10,
-                pool_maxsize=self.MAX_WORKERS + 10,
+                pool_connections=self._max_workers + 10,
+                pool_maxsize=self._max_workers + 10,
                 max_retries=retry_strategy,
             )
             self._session = requests.Session()
@@ -310,6 +312,9 @@ class ClientV2:
         except (ValueError, TypeError):
             message = response_body or f"HTTP {status_code}"
 
+        # Close response to release connection back to pool before raising
+        response.close()
+
         if status_code == 403:
             raise JQuantsForbiddenError(message, status_code, response_body)
         elif status_code == 429:
@@ -326,7 +331,7 @@ class ClientV2:
         json_data: Optional[dict] = None,
     ) -> requests.Response:
         """
-        Send HTTP request with proper headers and timeout.
+        Send HTTP request with proper headers, timeout, and rate limiting.
 
         Args:
             method: HTTP method ("GET" or "POST")
@@ -347,19 +352,42 @@ class ClientV2:
         url = f"{self.JQUANTS_API_BASE}{path}"
         session = self._request_session()
 
-        response = session.request(
-            method,
-            url,
-            params=params,
-            json=json_data,
-            headers=self._base_headers(),
-            timeout=self.REQUEST_TIMEOUT,
+        # 429 retry loop with rate limiting on each attempt
+        for attempt in range(self._retry_max_attempts + 1):
+            # Rate limiting: wait before each request (including retries)
+            self._pacer.wait()
+
+            response = session.request(
+                method,
+                url,
+                params=params,
+                json=json_data,
+                headers=self._base_headers(),
+                timeout=self.REQUEST_TIMEOUT,
+            )
+
+            if response.status_code == 429:
+                # Check if retry is disabled or max attempts reached
+                is_last_attempt = attempt >= self._retry_max_attempts
+                if not self._retry_on_429 or is_last_attempt:
+                    self._handle_error_response(response)
+                # Close response to release connection back to pool
+                response.close()
+                # Wait and retry
+                time.sleep(self._retry_wait_seconds)
+                continue
+
+            if not response.ok:
+                self._handle_error_response(response)
+
+            return response
+
+        # Should not reach here, but handle edge case
+        raise JQuantsAPIError(
+            "Unexpected error: retry loop exited without response",
+            status_code=None,
+            response_body=None,
         )
-
-        if not response.ok:
-            self._handle_error_response(response)
-
-        return response
 
     def _get_raw(
         self,

--- a/jquants/pacer.py
+++ b/jquants/pacer.py
@@ -1,0 +1,69 @@
+"""Leaky Bucket rate limiter for J-Quants API V2."""
+
+import threading
+import time
+
+
+class Pacer:
+    """Leaky Bucket方式のレートリミッター.
+
+    一定間隔でリクエストを整流化し、バーストを一切許容しない。
+    """
+
+    def __init__(self, rate: int) -> None:
+        """Initialize Pacer.
+
+        Args:
+            rate: 1分あたりの最大リクエスト数 (req/min)
+
+        Raises:
+            ValueError: rate <= 0 の場合
+        """
+        if rate <= 0:
+            raise ValueError(f"rate must be positive, got {rate}")
+
+        self._rate = rate
+        self._interval = 60.0 / rate
+        self._last_request_time: float | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def interval(self) -> float:
+        """リクエスト間隔（秒）."""
+        return self._interval
+
+    def wait(self) -> float:
+        """次のリクエストまで待機する.
+
+        Returns:
+            実際に待機した時間（秒）
+
+        Note:
+            - 初回は即時（待機時間=0）
+            - スレッドセーフであること
+        """
+        with self._lock:
+            now = time.monotonic()
+
+            # 初回は即時発行
+            if self._last_request_time is None:
+                self._last_request_time = now
+                return 0.0
+
+            # 前回リクエストからの経過時間
+            elapsed = now - self._last_request_time
+            wait_time = self._interval - elapsed
+
+            if wait_time > 0:
+                time.sleep(wait_time)
+                self._last_request_time = time.monotonic()
+                return wait_time
+            else:
+                # 間隔以上経過している場合は即時
+                self._last_request_time = now
+                return 0.0
+
+    def reset(self) -> None:
+        """状態をリセットする（テスト用）."""
+        with self._lock:
+            self._last_request_time = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,14 @@ skip_glob = ["**/node_modules/**"]
 [tool.pytest.ini_options]
 markers = [
     "integration: marks tests as integration tests requiring API key (run with 'pytest -m integration')",
+    "slow: marks tests as slow (run with 'pytest -m slow' or 'pytest --run-slow')",
 ]
 testpaths = ["tests"]
-# Exclude integration tests by default (they require API key and network access)
-# Run integration tests explicitly: pytest -m integration
-addopts = "-v -m 'not integration'"
+# Exclude integration and slow tests by default
+# Run slow tests: pytest --run-slow (or pytest -m slow)
+# Run integration tests: pytest -m integration
+# Run all tests: pytest --run-slow -m ''
+addopts = "-v -m 'not integration and not slow'"
 
 [tool.coverage.run]
 omit = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Pytest configuration for all tests."""
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add custom command line options."""
+    parser.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="Run slow tests (tests that use real time.sleep)",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Modify pytest configuration based on options."""
+    if config.getoption("--run-slow"):
+        # Override the default marker expression to include slow tests
+        # This removes 'not slow' from the filter while keeping other filters
+        current = config.option.markexpr
+        if current:
+            # Remove 'not slow' and 'and not slow' from expression
+            new_expr = current.replace(" and not slow", "").replace("not slow", "")
+            # Clean up any leading/trailing 'and'
+            new_expr = new_expr.strip()
+            if new_expr.startswith("and "):
+                new_expr = new_expr[4:]
+            if new_expr.endswith(" and"):
+                new_expr = new_expr[:-4]
+            # Handle empty expression
+            if not new_expr or new_expr == "and":
+                new_expr = ""
+            config.option.markexpr = new_expr

--- a/tests/test_client_v2.py
+++ b/tests/test_client_v2.py
@@ -492,7 +492,8 @@ class TestClientV2HTTPSession:
         retry = adapter.max_retries
 
         assert retry.total == 3
-        assert 429 in retry.status_forcelist
+        # 429 is excluded from urllib3 retry for custom retry logic
+        assert 429 not in retry.status_forcelist
         assert 500 in retry.status_forcelist
         assert 502 in retry.status_forcelist
         assert 503 in retry.status_forcelist
@@ -693,7 +694,8 @@ class TestClientV2ErrorHandling:
         """R004: 429 should raise JQuantsRateLimitError."""
         from jquants import ClientV2
 
-        client = ClientV2(api_key="test_api_key")
+        # retry_on_429=False で即座に例外を発生させる
+        client = ClientV2(api_key="test_api_key", retry_on_429=False)
 
         with patch.object(client, "_request_session") as mock_session_method:
             mock_session = MagicMock()

--- a/tests/test_integration/test_rate_limiter.py
+++ b/tests/test_integration/test_rate_limiter.py
@@ -1,0 +1,257 @@
+"""Sub-Phase 3.1.5 Integration tests: Rate Limiter (RATE-001~008)."""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jquants.exceptions import JQuantsRateLimitError
+
+
+class TestRateLimiterDefaultBehavior:
+    """Test rate limiter default behavior (RATE-001, RATE-006)."""
+
+    def test_rate_limit_none_uses_free_plan_default(self):
+        """RATE-001: rate_limit=None時の挙動"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", rate_limit=None)
+
+        # Freeプラン（5 req/min）がデフォルト
+        assert client._rate_limit == 5
+        # 間隔は12秒（60/5）
+        assert client._pacer.interval == pytest.approx(12.0, rel=1e-6)
+
+    def test_max_workers_1_is_serial(self):
+        """RATE-006: max_workers=1で直列取得"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", max_workers=1)
+
+        assert client._max_workers == 1
+
+
+class TestRateLimiterCustomRate:
+    """Test rate limiter with custom rate (RATE-002)."""
+
+    def test_rate_limit_60_custom_value(self):
+        """RATE-002: rate_limit=60等カスタム値"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", rate_limit=60)
+
+        assert client._rate_limit == 60
+        # 間隔は1秒（60/60）
+        assert client._pacer.interval == pytest.approx(1.0, rel=1e-6)
+
+    def test_rate_limit_120_custom_value(self):
+        """RATE-002: rate_limit=120等カスタム値"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", rate_limit=120)
+
+        assert client._rate_limit == 120
+        # 間隔は0.5秒（60/120）
+        assert client._pacer.interval == pytest.approx(0.5, rel=1e-6)
+
+
+class TestRateLimiterPacing:
+    """Test rate limiter pacing behavior (RATE-003)."""
+
+    def test_consecutive_requests_with_pacing(self):
+        """RATE-003: 連続リクエストで待機発生"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", rate_limit=120)  # 0.5秒間隔
+
+        # Pacerの動作を直接テスト
+        start = time.monotonic()
+        client._pacer.wait()  # 初回：即時
+        client._pacer.wait()  # 2回目：0.5秒待機
+        client._pacer.wait()  # 3回目：0.5秒待機
+        elapsed = time.monotonic() - start
+
+        # 最低約1.0秒経過すべき
+        assert elapsed >= 0.9
+
+    def test_pacer_integrated_with_client(self):
+        """RATE-003: ClientV2にPacerが統合されている"""
+        from jquants import ClientV2
+        from jquants.pacer import Pacer
+
+        client = ClientV2(api_key="test_api_key", rate_limit=60)
+
+        # Pacerインスタンスが存在
+        assert hasattr(client, "_pacer")
+        assert isinstance(client._pacer, Pacer)
+
+
+class TestRateLimiter429Retry:
+    """Test 429 retry behavior (RATE-004, RATE-005)."""
+
+    def test_429_waits_before_retry(self):
+        """RATE-004: 429で5分10秒待ってリトライ"""
+        from jquants import ClientV2
+
+        client = ClientV2(
+            api_key="test_api_key",
+            retry_on_429=True,
+            retry_wait_seconds=310,
+            retry_max_attempts=3,
+        )
+
+        # 設定が正しく反映されている
+        assert client._retry_on_429 is True
+        assert client._retry_wait_seconds == 310
+        assert client._retry_max_attempts == 3
+
+    def test_429_immediate_exception_when_disabled(self):
+        """RATE-005: retry_on_429=Falseで即例外"""
+        from jquants import ClientV2
+
+        client = ClientV2(
+            api_key="test_api_key",
+            retry_on_429=False,
+        )
+
+        # retry_on_429=False が設定されている
+        assert client._retry_on_429 is False
+
+    def test_429_retry_mechanism_with_mock(self):
+        """RATE-004: 429リトライメカニズム（モック）"""
+        from jquants import ClientV2
+
+        client = ClientV2(
+            api_key="test_api_key",
+            retry_on_429=True,
+            retry_wait_seconds=1,  # テスト用に短縮
+            retry_max_attempts=2,
+        )
+
+        # _request_with_rate_limit メソッドが実装されたら使用
+        # 現時点ではパラメータの設定のみ確認
+        assert client._retry_wait_seconds == 1
+        assert client._retry_max_attempts == 2
+
+
+class TestRateLimiterParallel:
+    """Test parallel execution (RATE-007, RATE-008)."""
+
+    def test_max_workers_greater_than_1_enables_parallel(self):
+        """RATE-007: max_workers>1で並列取得"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", max_workers=5)
+
+        assert client._max_workers == 5
+
+    def test_parallel_access_no_race_condition(self):
+        """RATE-008: 並列アクセスで競合なし"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", rate_limit=60)  # 1秒間隔
+
+        timestamps: list[float] = []
+        lock = threading.Lock()
+
+        def worker():
+            client._pacer.wait()
+            with lock:
+                timestamps.append(time.monotonic())
+
+        threads = [threading.Thread(target=worker) for _ in range(3)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # タイムスタンプを時系列順にソート
+        timestamps.sort()
+
+        # 各リクエスト間の間隔が約1秒であることを確認
+        for i in range(1, len(timestamps)):
+            diff = timestamps[i] - timestamps[i - 1]
+            # 間隔は最低でも0.9秒（少しの誤差を許容）
+            assert diff >= 0.9, f"Interval {i}: {diff} < 0.9"
+
+
+class TestRateLimiter429Integration:
+    """Test 429 handling integration."""
+
+    def test_429_response_raises_rate_limit_error(self):
+        """429レスポンスでJQuantsRateLimitErrorが発生"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_request_session") as mock_session_method:
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.ok = False
+            mock_response.status_code = 429
+            mock_response.text = '{"message": "Rate limit exceeded"}'
+            mock_response.json.return_value = {"message": "Rate limit exceeded"}
+            mock_session.request.return_value = mock_response
+            mock_session_method.return_value = mock_session
+
+            with pytest.raises(JQuantsRateLimitError) as exc_info:
+                client._request("GET", "/path")
+
+            assert exc_info.value.status_code == 429
+
+    def test_pacer_works_between_requests(self):
+        """Pacerがリクエスト間で動作することを確認"""
+        from jquants import ClientV2
+
+        client = ClientV2(api_key="test_api_key", rate_limit=120)  # 0.5秒間隔
+
+        # Pacerを直接使用してリクエスト間の待機を確認
+        wait1 = client._pacer.wait()  # 初回：即時
+        assert wait1 == 0.0
+
+        wait2 = client._pacer.wait()  # 2回目：0.5秒待機
+        assert wait2 >= 0.4
+
+
+class TestRateLimiterAllParametersCombined:
+    """Test all rate limiter parameters combined."""
+
+    def test_all_parameters_set_correctly(self):
+        """全パラメータが正しく設定される"""
+        from jquants import ClientV2
+
+        client = ClientV2(
+            api_key="test_api_key",
+            rate_limit=100,
+            max_workers=3,
+            retry_on_429=True,
+            retry_wait_seconds=600,
+            retry_max_attempts=5,
+        )
+
+        assert client._rate_limit == 100
+        assert client._max_workers == 3
+        assert client._retry_on_429 is True
+        assert client._retry_wait_seconds == 600
+        assert client._retry_max_attempts == 5
+        assert client._pacer.interval == pytest.approx(0.6, rel=1e-6)
+
+    def test_default_parameters_are_safe(self):
+        """デフォルトパラメータが最安全である"""
+        from jquants import ClientV2
+
+        # 明示的なパラメータなしで初期化
+        client = ClientV2(api_key="test_api_key")
+
+        # Freeプランのレート（5 req/min）
+        assert client._rate_limit == 5
+        # 直列（並列化なし）
+        assert client._max_workers == 1
+        # リトライ有効
+        assert client._retry_on_429 is True
+        # 5分10秒待機
+        assert client._retry_wait_seconds == 310
+        # 最大3回リトライ
+        assert client._retry_max_attempts == 3

--- a/tests/test_pacer.py
+++ b/tests/test_pacer.py
@@ -90,6 +90,7 @@ class TestPacerFirstWait:
         assert elapsed < 0.1
 
 
+@pytest.mark.slow
 class TestPacerConsecutiveWait:
     """Test Pacer consecutive wait behavior (PACER-005)."""
 
@@ -130,6 +131,7 @@ class TestPacerConsecutiveWait:
         assert total_elapsed >= 0.9
 
 
+@pytest.mark.slow
 class TestPacerElapsedTime:
     """Test Pacer elapsed time consideration (PACER-006)."""
 
@@ -191,6 +193,7 @@ class TestPacerReset:
         assert elapsed < 0.1
 
 
+@pytest.mark.slow
 class TestPacerThreadSafety:
     """Test Pacer thread safety (PACER-008)."""
 

--- a/tests/test_pacer.py
+++ b/tests/test_pacer.py
@@ -1,0 +1,324 @@
+"""Sub-Phase 3.1.5 TDD tests: Pacer (Leaky Bucket rate limiter)."""
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+class TestPacerInterval:
+    """Test Pacer interval calculation (PACER-001, PACER-002)."""
+
+    def test_rate_120_gives_interval_0_5(self):
+        """PACER-001: rate=120 → interval=0.5秒"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=120)
+        assert pacer.interval == pytest.approx(0.5, rel=1e-6)
+
+    def test_rate_5_gives_interval_12(self):
+        """PACER-002: rate=5 → interval=12秒"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=5)
+        assert pacer.interval == pytest.approx(12.0, rel=1e-6)
+
+    def test_rate_60_gives_interval_1(self):
+        """rate=60 → interval=1.0秒"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=60)
+        assert pacer.interval == pytest.approx(1.0, rel=1e-6)
+
+    def test_rate_1_gives_interval_60(self):
+        """rate=1 → interval=60秒"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=1)
+        assert pacer.interval == pytest.approx(60.0, rel=1e-6)
+
+
+class TestPacerValidation:
+    """Test Pacer parameter validation (PACER-003)."""
+
+    def test_rate_zero_raises_valueerror(self):
+        """PACER-003: rate=0 → ValueError"""
+        from jquants.pacer import Pacer
+
+        with pytest.raises(ValueError) as exc_info:
+            Pacer(rate=0)
+        assert "rate" in str(exc_info.value).lower()
+
+    def test_rate_negative_raises_valueerror(self):
+        """PACER-003: rate=-1 → ValueError"""
+        from jquants.pacer import Pacer
+
+        with pytest.raises(ValueError) as exc_info:
+            Pacer(rate=-1)
+        assert "rate" in str(exc_info.value).lower()
+
+    def test_rate_negative_large_raises_valueerror(self):
+        """PACER-003: rate=-100 → ValueError"""
+        from jquants.pacer import Pacer
+
+        with pytest.raises(ValueError) as exc_info:
+            Pacer(rate=-100)
+        assert "rate" in str(exc_info.value).lower()
+
+
+class TestPacerFirstWait:
+    """Test Pacer first wait behavior (PACER-004)."""
+
+    def test_first_wait_returns_zero(self):
+        """PACER-004: 初回wait() → 待機時間=0"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=60)
+        waited = pacer.wait()
+        assert waited == pytest.approx(0.0, abs=0.01)
+
+    def test_first_wait_is_immediate(self):
+        """PACER-004: 初回wait()は即時発行"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=1)  # 60秒間隔
+        start = time.monotonic()
+        pacer.wait()
+        elapsed = time.monotonic() - start
+        # 初回は即時（0.1秒未満で完了すべき）
+        assert elapsed < 0.1
+
+
+class TestPacerConsecutiveWait:
+    """Test Pacer consecutive wait behavior (PACER-005)."""
+
+    def test_consecutive_waits_maintain_interval(self):
+        """PACER-005: 連続wait() → 間隔維持"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=120)  # 0.5秒間隔
+
+        # 初回
+        pacer.wait()
+
+        # 2回目は0.5秒待機
+        start = time.monotonic()
+        waited = pacer.wait()
+        elapsed = time.monotonic() - start
+
+        # 0.5秒 ± 0.1秒の範囲
+        assert waited >= 0.4
+        assert elapsed >= 0.4
+
+    def test_consecutive_waits_multiple_times(self):
+        """PACER-005: 複数回連続wait()でも間隔維持"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=120)  # 0.5秒間隔
+
+        start_total = time.monotonic()
+
+        # 3回連続でwait
+        pacer.wait()  # 初回：即時
+        pacer.wait()  # 2回目：0.5秒待機
+        pacer.wait()  # 3回目：0.5秒待機
+
+        total_elapsed = time.monotonic() - start_total
+
+        # 最低でも約1.0秒（0.5 + 0.5）経過すべき
+        assert total_elapsed >= 0.9
+
+
+class TestPacerElapsedTime:
+    """Test Pacer elapsed time consideration (PACER-006)."""
+
+    def test_wait_after_interval_is_immediate(self):
+        """PACER-006: 間隔経過後wait() → 待機時間=0"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=120)  # 0.5秒間隔
+
+        pacer.wait()  # 初回
+        time.sleep(0.6)  # 間隔以上待つ
+
+        start = time.monotonic()
+        waited = pacer.wait()
+        elapsed = time.monotonic() - start
+
+        # 即時発行されるべき
+        assert waited < 0.1
+        assert elapsed < 0.1
+
+    def test_wait_partial_elapsed_waits_remaining(self):
+        """PACER-006: 間隔未満経過 → 残り時間だけ待機"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=120)  # 0.5秒間隔
+
+        pacer.wait()  # 初回
+        time.sleep(0.2)  # 0.2秒経過
+
+        start = time.monotonic()
+        waited = pacer.wait()
+        elapsed = time.monotonic() - start
+
+        # 約0.3秒待機すべき（0.5 - 0.2 = 0.3）
+        assert waited >= 0.2
+        assert elapsed >= 0.2
+
+
+class TestPacerReset:
+    """Test Pacer reset behavior (PACER-007)."""
+
+    def test_reset_makes_next_wait_immediate(self):
+        """PACER-007: reset() → 次回即時"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=120)  # 0.5秒間隔
+
+        pacer.wait()  # 初回
+        # 通常ならここで wait() すると0.5秒待機
+
+        pacer.reset()  # リセット
+
+        start = time.monotonic()
+        waited = pacer.wait()
+        elapsed = time.monotonic() - start
+
+        # リセット後は初回扱い → 即時
+        assert waited < 0.05
+        assert elapsed < 0.1
+
+
+class TestPacerThreadSafety:
+    """Test Pacer thread safety (PACER-008)."""
+
+    def test_concurrent_waits_maintain_interval(self):
+        """PACER-008: 複数スレッドから同時wait() → 競合なし"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=60)  # 1秒間隔
+        timestamps: list[float] = []
+        lock = threading.Lock()
+
+        def worker():
+            pacer.wait()
+            with lock:
+                timestamps.append(time.monotonic())
+
+        threads = [threading.Thread(target=worker) for _ in range(3)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # タイムスタンプを時系列順にソート
+        timestamps.sort()
+
+        # 各リクエスト間の間隔が約1秒であることを確認
+        for i in range(1, len(timestamps)):
+            diff = timestamps[i] - timestamps[i - 1]
+            # 間隔は最低でも0.9秒（少しの誤差を許容）
+            assert diff >= 0.9, f"Interval {i}: {diff} < 0.9"
+
+    def test_concurrent_waits_no_deadlock(self):
+        """PACER-008: 並列アクセスでデッドロックしない"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=1000)  # 高速（0.06秒間隔）
+        completed = []
+        lock = threading.Lock()
+
+        def worker(worker_id: int):
+            for _ in range(5):
+                pacer.wait()
+            with lock:
+                completed.append(worker_id)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+
+        for t in threads:
+            t.start()
+
+        # 10秒以内に完了すべき（デッドロックしていなければ）
+        for t in threads:
+            t.join(timeout=10)
+            assert not t.is_alive(), "Thread did not complete - possible deadlock"
+
+        assert len(completed) == 5
+
+    def test_concurrent_waits_total_time_consistent(self):
+        """PACER-008: 並列時の合計待機時間が理論値と一致"""
+        from jquants.pacer import Pacer
+
+        pacer = Pacer(rate=120)  # 0.5秒間隔
+
+        num_workers = 4
+        wait_times: list[float] = []
+        lock = threading.Lock()
+
+        def worker():
+            waited = pacer.wait()
+            with lock:
+                wait_times.append(waited)
+
+        threads = [threading.Thread(target=worker) for _ in range(num_workers)]
+
+        start_time = time.monotonic()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        total_elapsed = time.monotonic() - start_time
+
+        # 4リクエストで3間隔 → 最低1.5秒（0.5 * 3）
+        # 実際には並列起動のオーバーヘッドがあるので少し余裕を見る
+        assert total_elapsed >= 1.3
+
+
+class TestPacerMockedTime:
+    """Test Pacer with mocked time for precise control."""
+
+    def test_wait_calculation_precise(self):
+        """wait()の計算が正確"""
+        from jquants.pacer import Pacer
+
+        with patch("time.monotonic") as mock_time:
+            with patch("time.sleep") as mock_sleep:
+                mock_time.return_value = 100.0
+
+                pacer = Pacer(rate=60)  # 1秒間隔
+
+                # 初回
+                waited = pacer.wait()
+                assert waited == 0.0
+                mock_sleep.assert_not_called()
+
+                # 2回目（0.3秒経過）
+                mock_time.return_value = 100.3
+                waited = pacer.wait()
+                # 1.0 - 0.3 = 0.7秒待機
+                mock_sleep.assert_called_once()
+                assert mock_sleep.call_args[0][0] == pytest.approx(0.7, rel=1e-6)
+
+    def test_wait_no_sleep_when_elapsed_exceeds_interval(self):
+        """間隔以上経過後は sleep しない"""
+        from jquants.pacer import Pacer
+
+        with patch("time.monotonic") as mock_time:
+            with patch("time.sleep") as mock_sleep:
+                mock_time.return_value = 100.0
+
+                pacer = Pacer(rate=60)  # 1秒間隔
+
+                # 初回
+                pacer.wait()
+
+                # 2回目（2秒経過 - 間隔の2倍）
+                mock_time.return_value = 102.0
+                waited = pacer.wait()
+
+                assert waited == 0.0
+                mock_sleep.assert_not_called()


### PR DESCRIPTION
## Summary

- `_request` 内で `_pacer.wait()` を呼び出し、全リクエストでレートリミットを適用
- urllib3 Retry から 429 を除外し、自前の 429 リトライロジックを実装
- 接続プールに `_max_workers` を反映
- `response.close()` を適切な箇所に追加
- slowテスト分離（`--run-slow` オプション対応）

## Test plan

- [x] `make lint` パス
- [x] 既存テストとの互換性確認
- [ ] `pytest --run-slow` で実時間テスト実行

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)