### PR TITLE
feat: Sub-Phase 3.6 - Derivatives-Standard エンドポイント実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ J-Quants API の各 API エンドポイントに対応しています。
 
 - get_weekly_margin_range
 - get_short_selling_range
-- get_options_225_daily_range
+- get_index_option_range
 - get_markets_short_selling_positions_range
 - get_daily_margin_interest_range
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ J-Quants API の各 API エンドポイントに対応しています。
 
 - get_weekly_margin_range
 - get_short_selling_range
-- get_index_option_range
+- get_options_225_daily_range
 - get_markets_short_selling_positions_range
 - get_daily_margin_interest_range
 

--- a/docs/phase3-design.md
+++ b/docs/phase3-design.md
@@ -201,7 +201,7 @@ class JQuantsRateLimitError(JQuantsAPIError):
 
 | V2 エンドポイント | メソッド名 | 並列取得 |
 |------------------|-----------|---------|
-| `/v2/derivatives/bars/daily/options/225` | `get_option_index_option()` | `get_index_option_range()` |
+| `/v2/derivatives/bars/daily/options/225` | `get_options_225_daily()` | `get_options_225_daily_range()` |
 | `/v2/derivatives/bars/daily/futures` | `get_derivatives_futures()` | `get_derivatives_futures_range()` |
 | `/v2/derivatives/bars/daily/options` | `get_derivatives_options()` | `get_derivatives_options_range()` |
 

--- a/jquants/client_v2.py
+++ b/jquants/client_v2.py
@@ -1086,7 +1086,7 @@ class ClientV2:
     # Derivatives endpoints
     # =========================================================================
 
-    def get_index_option(self, date: str) -> pd.DataFrame:
+    def get_options_225_daily(self, date: str) -> pd.DataFrame:
         """
         日経225オプション日足データを取得する。
 
@@ -1105,7 +1105,7 @@ class ClientV2:
             日付カラム（LTD, SQD）で空文字の場合は NaT に変換される。
         """
         if not date:
-            raise ValueError("'date' is required for get_index_option()")
+            raise ValueError("'date' is required for get_options_225_daily()")
 
         params: dict[str, str] = {"date": date}
 
@@ -1120,7 +1120,7 @@ class ClientV2:
             sort_columns=["Code"],
         )
 
-    def get_index_option_range(
+    def get_options_225_daily_range(
         self,
         start_dt: Union[str, datetime, date_type],
         end_dt: Optional[Union[str, datetime, date_type]] = None,
@@ -1163,11 +1163,11 @@ class ClientV2:
         # Fetch data
         if self._max_workers == 1:
             # Sequential execution
-            dfs = [self.get_index_option(date=d) for d in dates]
+            dfs = [self.get_options_225_daily(date=d) for d in dates]
         else:
             # Parallel execution with ThreadPoolExecutor
             def fetch_date(d: str) -> pd.DataFrame:
-                return self.get_index_option(date=d)
+                return self.get_options_225_daily(date=d)
 
             with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
                 dfs = list(executor.map(fetch_date, dates))

--- a/jquants/client_v2.py
+++ b/jquants/client_v2.py
@@ -1111,6 +1111,7 @@ class ClientV2:
         if not isinstance(date, str) or not date.strip():
             raise ValueError("'date' is required for get_options_225_daily()")
 
+        date = date.strip()
         params: dict[str, str] = {"date": date}
 
         data = self._paginated_get("/derivatives/bars/daily/options/225", params=params)

--- a/jquants/constants_v2.py
+++ b/jquants/constants_v2.py
@@ -275,3 +275,57 @@ MARKETS_MARGIN_ALERT_COLUMNS = [
     "LongStdOutChg",
     "TSEMrgnRegCls",
 ]
+
+# =============================================================================
+# Derivatives endpoints
+# =============================================================================
+
+# derivatives/bars/daily/options/225 - 日経225オプション日足
+# ref: https://jpx-jquants.com/ja/spec/drv-bars-daily-opt-225
+DERIVATIVES_OPTIONS_225_COLUMNS = [
+    # 基本情報
+    "Date",
+    "Code",
+    # 全セッションOHLC
+    "O",
+    "H",
+    "L",
+    "C",
+    # 夜間セッションOHLC（初回取引日は空文字）
+    "EO",
+    "EH",
+    "EL",
+    "EC",
+    # 日中セッションOHLC
+    "AO",
+    "AH",
+    "AL",
+    "AC",
+    # 出来高・建玉
+    "Vo",
+    "OI",
+    "Va",
+    "VoOA",
+    # 契約情報
+    "CM",
+    "Strike",
+    "PCDiv",
+    # 期日情報
+    "LTD",
+    "SQD",
+    # 価格・ボラティリティ（2016-07-19以降のみ）
+    "Settle",
+    "Theo",
+    "BaseVol",
+    "UnderPx",
+    "IV",
+    "IR",
+    # 管理区分
+    "EmMrgnTrgDiv",
+]
+
+# 日付型として扱うカラム
+DERIVATIVES_OPTIONS_225_DATE_COLUMNS = ["Date", "LTD", "SQD"]
+
+# 数値型変換が必要なカラム（夜間セッションは初回取引日で空文字となる）
+DERIVATIVES_OPTIONS_225_NUMERIC_COLUMNS = ["EO", "EH", "EL", "EC"]

--- a/tests/test_client_v2_derivatives.py
+++ b/tests/test_client_v2_derivatives.py
@@ -11,7 +11,7 @@ from jquants import constants_v2 as constants
 
 
 class TestGetIndexOption:
-    """Test get_index_option() method."""
+    """Test get_options_225_daily() method."""
 
     def test_returns_dataframe(self):
         """Should return a pandas DataFrame."""
@@ -53,7 +53,7 @@ class TestGetIndexOption:
                 },
             ]
 
-            result = client.get_index_option(date="2024-01-04")
+            result = client.get_options_225_daily(date="2024-01-04")
 
             assert isinstance(result, pd.DataFrame)
 
@@ -62,14 +62,14 @@ class TestGetIndexOption:
         client = ClientV2(api_key="test_api_key")
 
         with pytest.raises(TypeError):
-            client.get_index_option()  # type: ignore
+            client.get_options_225_daily()  # type: ignore
 
     def test_date_empty_string_raises_valueerror(self):
         """Empty string date should raise ValueError."""
         client = ClientV2(api_key="test_api_key")
 
         with pytest.raises(ValueError) as exc_info:
-            client.get_index_option(date="")
+            client.get_options_225_daily(date="")
 
         assert "'date' is required" in str(exc_info.value)
 
@@ -80,7 +80,7 @@ class TestGetIndexOption:
         with patch.object(client, "_paginated_get") as mock_get:
             mock_get.return_value = []
 
-            client.get_index_option(date="2024-01-04")
+            client.get_options_225_daily(date="2024-01-04")
 
             mock_get.assert_called_once()
             call_kwargs = mock_get.call_args[1]
@@ -93,7 +93,7 @@ class TestGetIndexOption:
         with patch.object(client, "_paginated_get") as mock_get:
             mock_get.return_value = []
 
-            client.get_index_option(date="2024-01-04")
+            client.get_options_225_daily(date="2024-01-04")
 
             mock_get.assert_called_once_with(
                 "/derivatives/bars/daily/options/225",
@@ -107,7 +107,7 @@ class TestGetIndexOption:
         with patch.object(client, "_paginated_get") as mock_get:
             mock_get.return_value = []
 
-            result = client.get_index_option(date="2024-01-04")
+            result = client.get_options_225_daily(date="2024-01-04")
 
             assert isinstance(result, pd.DataFrame)
             assert len(result) == 0
@@ -153,7 +153,7 @@ class TestGetIndexOption:
                 },
             ]
 
-            result = client.get_index_option(date="2024-01-04")
+            result = client.get_options_225_daily(date="2024-01-04")
 
             assert pd.api.types.is_datetime64_any_dtype(result["Date"])
             assert pd.api.types.is_datetime64_any_dtype(result["LTD"])
@@ -199,7 +199,7 @@ class TestGetIndexOption:
                 },
             ]
 
-            result = client.get_index_option(date="2024-01-04")
+            result = client.get_options_225_daily(date="2024-01-04")
 
             assert pd.isna(result.iloc[0]["LTD"])
             assert pd.isna(result.iloc[0]["SQD"])
@@ -244,7 +244,7 @@ class TestGetIndexOption:
                 },
             ]
 
-            result = client.get_index_option(date="2024-01-04")
+            result = client.get_options_225_daily(date="2024-01-04")
 
             assert pd.isna(result.iloc[0]["EO"])
             assert pd.isna(result.iloc[0]["EH"])
@@ -323,7 +323,7 @@ class TestGetIndexOption:
                 },
             ]
 
-            result = client.get_index_option(date="2024-01-04")
+            result = client.get_options_225_daily(date="2024-01-04")
 
             assert result.iloc[0]["Code"] == "188010019"
             assert result.iloc[1]["Code"] == "188020019"
@@ -369,19 +369,19 @@ class TestGetIndexOption:
                 },
             ]
 
-            result = client.get_index_option(date="2024-01-04")
+            result = client.get_options_225_daily(date="2024-01-04")
 
             assert list(result.columns) == constants.DERIVATIVES_OPTIONS_225_COLUMNS
 
 
 class TestGetIndexOptionRange:
-    """Test get_index_option_range() method."""
+    """Test get_options_225_daily_range() method."""
 
     def test_returns_dataframe(self):
         """Should return a pandas DataFrame."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 {
                     "Date": pd.to_datetime(["2024-01-04"]),
@@ -389,7 +389,7 @@ class TestGetIndexOptionRange:
                 }
             )
 
-            result = client.get_index_option_range(start_dt="2024-01-04")
+            result = client.get_options_225_daily_range(start_dt="2024-01-04")
 
             assert isinstance(result, pd.DataFrame)
 
@@ -398,19 +398,19 @@ class TestGetIndexOptionRange:
         client = ClientV2(api_key="test_api_key")
 
         with pytest.raises(TypeError):
-            client.get_index_option_range()  # type: ignore
+            client.get_options_225_daily_range()  # type: ignore
 
     def test_end_dt_defaults_to_today(self):
         """end_dt should default to today if not specified."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
 
             today = date.today().isoformat()
-            client.get_index_option_range(start_dt=today)
+            client.get_options_225_daily_range(start_dt=today)
 
             # Should be called once for today
             mock_get.assert_called_once()
@@ -422,7 +422,7 @@ class TestGetIndexOptionRange:
         client = ClientV2(api_key="test_api_key")
 
         with pytest.raises(ValueError) as exc_info:
-            client.get_index_option_range(
+            client.get_options_225_daily_range(
                 start_dt="2024-01-10",
                 end_dt="2024-01-01",
             )
@@ -430,15 +430,15 @@ class TestGetIndexOptionRange:
         assert "must not be after" in str(exc_info.value)
 
     def test_date_range_generates_correct_calls(self):
-        """Should call get_index_option for each date in range."""
+        """Should call get_options_225_daily for each date in range."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
 
-            client.get_index_option_range(
+            client.get_options_225_daily_range(
                 start_dt="2024-01-04",
                 end_dt="2024-01-06",
             )
@@ -452,12 +452,12 @@ class TestGetIndexOptionRange:
         """Should accept string date format."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
 
-            client.get_index_option_range(
+            client.get_options_225_daily_range(
                 start_dt="2024-01-04",
                 end_dt="2024-01-04",
             )
@@ -468,12 +468,12 @@ class TestGetIndexOptionRange:
         """Should accept date object."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
 
-            client.get_index_option_range(
+            client.get_options_225_daily_range(
                 start_dt=date(2024, 1, 4),
                 end_dt=date(2024, 1, 4),
             )
@@ -484,12 +484,12 @@ class TestGetIndexOptionRange:
         """Should accept datetime object."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
 
-            client.get_index_option_range(
+            client.get_options_225_daily_range(
                 start_dt=datetime(2024, 1, 4, 10, 0, 0),
                 end_dt=datetime(2024, 1, 4, 15, 0, 0),
             )
@@ -500,12 +500,12 @@ class TestGetIndexOptionRange:
         """Empty period should return empty DataFrame with correct columns."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
 
-            result = client.get_index_option_range(
+            result = client.get_options_225_daily_range(
                 start_dt="2024-01-04",
                 end_dt="2024-01-04",
             )
@@ -517,7 +517,7 @@ class TestGetIndexOptionRange:
         """Result should be sorted by Code, Date ascending."""
         client = ClientV2(api_key="test_api_key")
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             # Return data in wrong order
             mock_get.side_effect = [
                 pd.DataFrame(
@@ -544,7 +544,7 @@ class TestGetIndexOptionRange:
                 ),
             ]
 
-            result = client.get_index_option_range(
+            result = client.get_options_225_daily_range(
                 start_dt="2024-01-04",
                 end_dt="2024-01-05",
             )
@@ -556,12 +556,12 @@ class TestGetIndexOptionRange:
         """Should execute sequentially when max_workers=1 (default)."""
         client = ClientV2(api_key="test_api_key", max_workers=1)
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
 
-            client.get_index_option_range(
+            client.get_options_225_daily_range(
                 start_dt="2024-01-04",
                 end_dt="2024-01-05",
             )
@@ -573,7 +573,7 @@ class TestGetIndexOptionRange:
         """Should execute in parallel when max_workers > 1."""
         client = ClientV2(api_key="test_api_key", max_workers=2)
 
-        with patch.object(client, "get_index_option") as mock_get:
+        with patch.object(client, "get_options_225_daily") as mock_get:
             mock_get.return_value = pd.DataFrame(
                 columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
             )
@@ -585,7 +585,7 @@ class TestGetIndexOptionRange:
                     pd.DataFrame(columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS),
                 ]
 
-                client.get_index_option_range(
+                client.get_options_225_daily_range(
                     start_dt="2024-01-04",
                     end_dt="2024-01-05",
                 )

--- a/tests/test_client_v2_derivatives.py
+++ b/tests/test_client_v2_derivatives.py
@@ -1,0 +1,571 @@
+"""Sub-Phase 3.6 TDD tests: ClientV2 Derivatives endpoints."""
+
+from datetime import date, datetime
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from jquants import ClientV2
+from jquants import constants_v2 as constants
+
+
+class TestGetIndexOption:
+    """Test get_index_option() method."""
+
+    def test_returns_dataframe(self):
+        """Should return a pandas DataFrame."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = [
+                {
+                    "Date": "2024-01-04",
+                    "Code": "188010019",
+                    "O": 100.0,
+                    "H": 110.0,
+                    "L": 95.0,
+                    "C": 105.0,
+                    "EO": "",
+                    "EH": "",
+                    "EL": "",
+                    "EC": "",
+                    "AO": 100.0,
+                    "AH": 110.0,
+                    "AL": 95.0,
+                    "AC": 105.0,
+                    "Vo": 1000,
+                    "OI": 5000,
+                    "Va": 10500000,
+                    "VoOA": 100,
+                    "CM": "2024-01",
+                    "Strike": 36000,
+                    "PCDiv": "1",
+                    "LTD": "2024-01-12",
+                    "SQD": "2024-01-12",
+                    "Settle": 105.0,
+                    "Theo": 104.5,
+                    "BaseVol": 0.15,
+                    "UnderPx": 36500.0,
+                    "IV": 0.16,
+                    "IR": 0.01,
+                    "EmMrgnTrgDiv": "0",
+                },
+            ]
+
+            result = client.get_index_option(date="2024-01-04")
+
+            assert isinstance(result, pd.DataFrame)
+
+    def test_date_parameter_required(self):
+        """date parameter is required - should raise TypeError if missing."""
+        client = ClientV2(api_key="test_api_key")
+
+        with pytest.raises(TypeError):
+            client.get_index_option()  # type: ignore
+
+    def test_date_parameter_passed(self):
+        """date parameter should be passed to API."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = []
+
+            client.get_index_option(date="2024-01-04")
+
+            mock_get.assert_called_once()
+            call_kwargs = mock_get.call_args[1]
+            assert call_kwargs["params"]["date"] == "2024-01-04"
+
+    def test_empty_response_returns_empty_dataframe_with_columns(self):
+        """Empty response should return empty DataFrame with correct columns."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = []
+
+            result = client.get_index_option(date="2024-01-04")
+
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 0
+            assert list(result.columns) == constants.DERIVATIVES_OPTIONS_225_COLUMNS
+
+    def test_date_columns_converted_to_timestamp(self):
+        """Date, LTD, SQD columns should be converted to pd.Timestamp."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = [
+                {
+                    "Date": "2024-01-04",
+                    "Code": "188010019",
+                    "O": 100.0,
+                    "H": 110.0,
+                    "L": 95.0,
+                    "C": 105.0,
+                    "EO": 99.0,
+                    "EH": 100.0,
+                    "EL": 98.0,
+                    "EC": 99.5,
+                    "AO": 100.0,
+                    "AH": 110.0,
+                    "AL": 95.0,
+                    "AC": 105.0,
+                    "Vo": 1000,
+                    "OI": 5000,
+                    "Va": 10500000,
+                    "VoOA": 100,
+                    "CM": "2024-01",
+                    "Strike": 36000,
+                    "PCDiv": "1",
+                    "LTD": "2024-01-12",
+                    "SQD": "2024-01-12",
+                    "Settle": 105.0,
+                    "Theo": 104.5,
+                    "BaseVol": 0.15,
+                    "UnderPx": 36500.0,
+                    "IV": 0.16,
+                    "IR": 0.01,
+                    "EmMrgnTrgDiv": "0",
+                },
+            ]
+
+            result = client.get_index_option(date="2024-01-04")
+
+            assert pd.api.types.is_datetime64_any_dtype(result["Date"])
+            assert pd.api.types.is_datetime64_any_dtype(result["LTD"])
+            assert pd.api.types.is_datetime64_any_dtype(result["SQD"])
+
+    def test_date_columns_empty_string_becomes_nat(self):
+        """Empty string in date columns should become pd.NaT."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = [
+                {
+                    "Date": "2024-01-04",
+                    "Code": "188010019",
+                    "O": 100.0,
+                    "H": 110.0,
+                    "L": 95.0,
+                    "C": 105.0,
+                    "EO": "",
+                    "EH": "",
+                    "EL": "",
+                    "EC": "",
+                    "AO": 100.0,
+                    "AH": 110.0,
+                    "AL": 95.0,
+                    "AC": 105.0,
+                    "Vo": 1000,
+                    "OI": 5000,
+                    "Va": 10500000,
+                    "VoOA": 100,
+                    "CM": "2024-01",
+                    "Strike": 36000,
+                    "PCDiv": "1",
+                    "LTD": "",
+                    "SQD": "",
+                    "Settle": 105.0,
+                    "Theo": 104.5,
+                    "BaseVol": 0.15,
+                    "UnderPx": 36500.0,
+                    "IV": 0.16,
+                    "IR": 0.01,
+                    "EmMrgnTrgDiv": "0",
+                },
+            ]
+
+            result = client.get_index_option(date="2024-01-04")
+
+            assert pd.isna(result.iloc[0]["LTD"])
+            assert pd.isna(result.iloc[0]["SQD"])
+
+    def test_numeric_columns_empty_string_becomes_nan(self):
+        """Empty string in EO/EH/EL/EC should become NaN."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = [
+                {
+                    "Date": "2024-01-04",
+                    "Code": "188010019",
+                    "O": 100.0,
+                    "H": 110.0,
+                    "L": 95.0,
+                    "C": 105.0,
+                    "EO": "",
+                    "EH": "",
+                    "EL": "",
+                    "EC": "",
+                    "AO": 100.0,
+                    "AH": 110.0,
+                    "AL": 95.0,
+                    "AC": 105.0,
+                    "Vo": 1000,
+                    "OI": 5000,
+                    "Va": 10500000,
+                    "VoOA": 100,
+                    "CM": "2024-01",
+                    "Strike": 36000,
+                    "PCDiv": "1",
+                    "LTD": "2024-01-12",
+                    "SQD": "2024-01-12",
+                    "Settle": 105.0,
+                    "Theo": 104.5,
+                    "BaseVol": 0.15,
+                    "UnderPx": 36500.0,
+                    "IV": 0.16,
+                    "IR": 0.01,
+                    "EmMrgnTrgDiv": "0",
+                },
+            ]
+
+            result = client.get_index_option(date="2024-01-04")
+
+            assert pd.isna(result.iloc[0]["EO"])
+            assert pd.isna(result.iloc[0]["EH"])
+            assert pd.isna(result.iloc[0]["EL"])
+            assert pd.isna(result.iloc[0]["EC"])
+
+    def test_sorted_by_code_ascending(self):
+        """Result should be sorted by Code ascending."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = [
+                {
+                    "Date": "2024-01-04",
+                    "Code": "188020019",
+                    "O": 100.0,
+                    "H": 110.0,
+                    "L": 95.0,
+                    "C": 105.0,
+                    "EO": 99.0,
+                    "EH": 100.0,
+                    "EL": 98.0,
+                    "EC": 99.5,
+                    "AO": 100.0,
+                    "AH": 110.0,
+                    "AL": 95.0,
+                    "AC": 105.0,
+                    "Vo": 1000,
+                    "OI": 5000,
+                    "Va": 10500000,
+                    "VoOA": 100,
+                    "CM": "2024-01",
+                    "Strike": 37000,
+                    "PCDiv": "1",
+                    "LTD": "2024-01-12",
+                    "SQD": "2024-01-12",
+                    "Settle": 105.0,
+                    "Theo": 104.5,
+                    "BaseVol": 0.15,
+                    "UnderPx": 36500.0,
+                    "IV": 0.16,
+                    "IR": 0.01,
+                    "EmMrgnTrgDiv": "0",
+                },
+                {
+                    "Date": "2024-01-04",
+                    "Code": "188010019",
+                    "O": 100.0,
+                    "H": 110.0,
+                    "L": 95.0,
+                    "C": 105.0,
+                    "EO": 99.0,
+                    "EH": 100.0,
+                    "EL": 98.0,
+                    "EC": 99.5,
+                    "AO": 100.0,
+                    "AH": 110.0,
+                    "AL": 95.0,
+                    "AC": 105.0,
+                    "Vo": 1000,
+                    "OI": 5000,
+                    "Va": 10500000,
+                    "VoOA": 100,
+                    "CM": "2024-01",
+                    "Strike": 36000,
+                    "PCDiv": "1",
+                    "LTD": "2024-01-12",
+                    "SQD": "2024-01-12",
+                    "Settle": 105.0,
+                    "Theo": 104.5,
+                    "BaseVol": 0.15,
+                    "UnderPx": 36500.0,
+                    "IV": 0.16,
+                    "IR": 0.01,
+                    "EmMrgnTrgDiv": "0",
+                },
+            ]
+
+            result = client.get_index_option(date="2024-01-04")
+
+            assert result.iloc[0]["Code"] == "188010019"
+            assert result.iloc[1]["Code"] == "188020019"
+
+    def test_column_order_matches_constants(self):
+        """Column order should match constants definition."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            # Response with columns in different order
+            mock_get.return_value = [
+                {
+                    "Code": "188010019",
+                    "Date": "2024-01-04",
+                    "Strike": 36000,
+                    "O": 100.0,
+                    "H": 110.0,
+                    "L": 95.0,
+                    "C": 105.0,
+                    "EO": 99.0,
+                    "EH": 100.0,
+                    "EL": 98.0,
+                    "EC": 99.5,
+                    "AO": 100.0,
+                    "AH": 110.0,
+                    "AL": 95.0,
+                    "AC": 105.0,
+                    "Vo": 1000,
+                    "OI": 5000,
+                    "Va": 10500000,
+                    "VoOA": 100,
+                    "CM": "2024-01",
+                    "PCDiv": "1",
+                    "LTD": "2024-01-12",
+                    "SQD": "2024-01-12",
+                    "Settle": 105.0,
+                    "Theo": 104.5,
+                    "BaseVol": 0.15,
+                    "UnderPx": 36500.0,
+                    "IV": 0.16,
+                    "IR": 0.01,
+                    "EmMrgnTrgDiv": "0",
+                },
+            ]
+
+            result = client.get_index_option(date="2024-01-04")
+
+            assert list(result.columns) == constants.DERIVATIVES_OPTIONS_225_COLUMNS
+
+
+class TestGetIndexOptionRange:
+    """Test get_index_option_range() method."""
+
+    def test_returns_dataframe(self):
+        """Should return a pandas DataFrame."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                {
+                    "Date": pd.to_datetime(["2024-01-04"]),
+                    "Code": ["188010019"],
+                }
+            )
+
+            result = client.get_index_option_range(start_dt="2024-01-04")
+
+            assert isinstance(result, pd.DataFrame)
+
+    def test_start_dt_required(self):
+        """start_dt parameter is required."""
+        client = ClientV2(api_key="test_api_key")
+
+        with pytest.raises(TypeError):
+            client.get_index_option_range()  # type: ignore
+
+    def test_end_dt_defaults_to_today(self):
+        """end_dt should default to today if not specified."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            today = date.today().isoformat()
+            client.get_index_option_range(start_dt=today)
+
+            # Should be called once for today
+            mock_get.assert_called_once()
+            call_args = mock_get.call_args[1]
+            assert call_args["date"] == today
+
+    def test_start_dt_after_end_dt_raises_error(self):
+        """start_dt > end_dt should raise ValueError."""
+        client = ClientV2(api_key="test_api_key")
+
+        with pytest.raises(ValueError) as exc_info:
+            client.get_index_option_range(
+                start_dt="2024-01-10",
+                end_dt="2024-01-01",
+            )
+
+        assert "must not be after" in str(exc_info.value)
+
+    def test_date_range_generates_correct_calls(self):
+        """Should call get_index_option for each date in range."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            client.get_index_option_range(
+                start_dt="2024-01-04",
+                end_dt="2024-01-06",
+            )
+
+            # Should call for 3 days: 2024-01-04, 2024-01-05, 2024-01-06
+            assert mock_get.call_count == 3
+            dates_called = [call[1]["date"] for call in mock_get.call_args_list]
+            assert dates_called == ["2024-01-04", "2024-01-05", "2024-01-06"]
+
+    def test_accepts_string_date(self):
+        """Should accept string date format."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            client.get_index_option_range(
+                start_dt="2024-01-04",
+                end_dt="2024-01-04",
+            )
+
+            mock_get.assert_called_once()
+
+    def test_accepts_date_object(self):
+        """Should accept date object."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            client.get_index_option_range(
+                start_dt=date(2024, 1, 4),
+                end_dt=date(2024, 1, 4),
+            )
+
+            mock_get.assert_called_once()
+
+    def test_accepts_datetime_object(self):
+        """Should accept datetime object."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            client.get_index_option_range(
+                start_dt=datetime(2024, 1, 4, 10, 0, 0),
+                end_dt=datetime(2024, 1, 4, 15, 0, 0),
+            )
+
+            mock_get.assert_called_once()
+
+    def test_empty_period_returns_empty_dataframe_with_columns(self):
+        """Empty period should return empty DataFrame with correct columns."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            result = client.get_index_option_range(
+                start_dt="2024-01-04",
+                end_dt="2024-01-04",
+            )
+
+            assert isinstance(result, pd.DataFrame)
+            assert list(result.columns) == constants.DERIVATIVES_OPTIONS_225_COLUMNS
+
+    def test_sorted_by_code_and_date_ascending(self):
+        """Result should be sorted by Code, Date ascending."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "get_index_option") as mock_get:
+            # Return data in wrong order
+            mock_get.side_effect = [
+                pd.DataFrame(
+                    {
+                        "Date": pd.to_datetime(["2024-01-05"]),
+                        "Code": ["188010019"],
+                        **{
+                            col: [0]
+                            for col in constants.DERIVATIVES_OPTIONS_225_COLUMNS
+                            if col not in ["Date", "Code"]
+                        },
+                    }
+                ),
+                pd.DataFrame(
+                    {
+                        "Date": pd.to_datetime(["2024-01-04"]),
+                        "Code": ["188010019"],
+                        **{
+                            col: [0]
+                            for col in constants.DERIVATIVES_OPTIONS_225_COLUMNS
+                            if col not in ["Date", "Code"]
+                        },
+                    }
+                ),
+            ]
+
+            result = client.get_index_option_range(
+                start_dt="2024-01-04",
+                end_dt="2024-01-05",
+            )
+
+            # Should be sorted by Code, Date
+            assert result.iloc[0]["Date"] < result.iloc[1]["Date"]
+
+    def test_sequential_execution_with_max_workers_1(self):
+        """Should execute sequentially when max_workers=1 (default)."""
+        client = ClientV2(api_key="test_api_key", max_workers=1)
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            client.get_index_option_range(
+                start_dt="2024-01-04",
+                end_dt="2024-01-05",
+            )
+
+            # Sequential: 2 calls
+            assert mock_get.call_count == 2
+
+    def test_parallel_execution_with_max_workers_greater_than_1(self):
+        """Should execute in parallel when max_workers > 1."""
+        client = ClientV2(api_key="test_api_key", max_workers=2)
+
+        with patch.object(client, "get_index_option") as mock_get:
+            mock_get.return_value = pd.DataFrame(
+                columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS
+            )
+
+            with patch("jquants.client_v2.ThreadPoolExecutor") as mock_executor_class:
+                mock_executor = mock_executor_class.return_value.__enter__.return_value
+                mock_executor.map.return_value = [
+                    pd.DataFrame(columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS),
+                    pd.DataFrame(columns=constants.DERIVATIVES_OPTIONS_225_COLUMNS),
+                ]
+
+                client.get_index_option_range(
+                    start_dt="2024-01-04",
+                    end_dt="2024-01-05",
+                )
+
+                # ThreadPoolExecutor should be used
+                mock_executor_class.assert_called_once_with(max_workers=2)

--- a/tests/test_client_v2_derivatives.py
+++ b/tests/test_client_v2_derivatives.py
@@ -64,6 +64,15 @@ class TestGetIndexOption:
         with pytest.raises(TypeError):
             client.get_index_option()  # type: ignore
 
+    def test_date_empty_string_raises_valueerror(self):
+        """Empty string date should raise ValueError."""
+        client = ClientV2(api_key="test_api_key")
+
+        with pytest.raises(ValueError) as exc_info:
+            client.get_index_option(date="")
+
+        assert "'date' is required" in str(exc_info.value)
+
     def test_date_parameter_passed(self):
         """date parameter should be passed to API."""
         client = ClientV2(api_key="test_api_key")
@@ -76,6 +85,20 @@ class TestGetIndexOption:
             mock_get.assert_called_once()
             call_kwargs = mock_get.call_args[1]
             assert call_kwargs["params"]["date"] == "2024-01-04"
+
+    def test_correct_api_path_called(self):
+        """Should call the correct API path."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = []
+
+            client.get_index_option(date="2024-01-04")
+
+            mock_get.assert_called_once_with(
+                "/derivatives/bars/daily/options/225",
+                params={"date": "2024-01-04"},
+            )
 
     def test_empty_response_returns_empty_dataframe_with_columns(self):
         """Empty response should return empty DataFrame with correct columns."""

--- a/tests/test_client_v2_derivatives.py
+++ b/tests/test_client_v2_derivatives.py
@@ -73,6 +73,29 @@ class TestGetIndexOption:
 
         assert "'date' is required" in str(exc_info.value)
 
+    def test_date_whitespace_only_raises_valueerror(self):
+        """Whitespace-only date should raise ValueError."""
+        client = ClientV2(api_key="test_api_key")
+
+        with pytest.raises(ValueError) as exc_info:
+            client.get_options_225_daily(date="   ")
+
+        assert "'date' is required" in str(exc_info.value)
+
+    def test_date_with_whitespace_is_stripped(self):
+        """Date with surrounding whitespace should be stripped before API call."""
+        client = ClientV2(api_key="test_api_key")
+
+        with patch.object(client, "_paginated_get") as mock_get:
+            mock_get.return_value = []
+
+            client.get_options_225_daily(date="  2024-01-04  ")
+
+            mock_get.assert_called_once()
+            call_kwargs = mock_get.call_args[1]
+            # Verify the date is stripped before being passed to API
+            assert call_kwargs["params"]["date"] == "2024-01-04"
+
     def test_date_parameter_passed(self):
         """date parameter should be passed to API."""
         client = ClientV2(api_key="test_api_key")

--- a/tests/test_integration/test_derivatives.py
+++ b/tests/test_integration/test_derivatives.py
@@ -18,12 +18,12 @@ class TestDerivativesIntegration:
     """Integration tests for Derivatives endpoints."""
 
     @requires_api_key
-    def test_get_index_option(self, client):
-        """Test get_index_option returns valid DataFrame.
+    def test_get_options_225_daily(self, client):
+        """Test get_options_225_daily returns valid DataFrame.
 
         Note: The endpoint returns Nikkei 225 option data for the specified date.
         """
-        df = client.get_index_option(date="2024-12-27")
+        df = client.get_options_225_daily(date="2024-12-27")
 
         assert isinstance(df, pd.DataFrame)
         if not df.empty:
@@ -43,9 +43,9 @@ class TestDerivativesIntegration:
                 assert df["Code"].is_monotonic_increasing
 
     @requires_api_key
-    def test_get_index_option_column_types(self, client):
-        """Test get_index_option returns correct column types."""
-        df = client.get_index_option(date="2024-12-27")
+    def test_get_options_225_daily_column_types(self, client):
+        """Test get_options_225_daily returns correct column types."""
+        df = client.get_options_225_daily(date="2024-12-27")
 
         assert isinstance(df, pd.DataFrame)
         if not df.empty:
@@ -64,9 +64,9 @@ class TestDerivativesIntegration:
                     assert sample_cm[4] == "-"  # Separator
 
     @requires_api_key
-    def test_get_index_option_range(self, client):
-        """Test get_index_option_range returns valid DataFrame."""
-        df = client.get_index_option_range(
+    def test_get_options_225_daily_range(self, client):
+        """Test get_options_225_daily_range returns valid DataFrame."""
+        df = client.get_options_225_daily_range(
             start_dt="2024-12-26",
             end_dt="2024-12-27",
         )
@@ -88,13 +88,13 @@ class TestDerivativesIntegration:
                     )
 
     @requires_api_key
-    def test_get_index_option_empty_date(self, client):
-        """Test get_index_option with holiday returns empty DataFrame.
+    def test_get_options_225_daily_empty_date(self, client):
+        """Test get_options_225_daily with holiday returns empty DataFrame.
 
         Note: API returns empty list on holidays, not 404 error.
         """
         # 2024-01-01 is New Year's Day (holiday)
-        df = client.get_index_option(date="2024-01-01")
+        df = client.get_options_225_daily(date="2024-01-01")
 
         assert isinstance(df, pd.DataFrame)
         # Should return empty DataFrame (not error)
@@ -105,7 +105,7 @@ class TestDerivativesIntegration:
     @requires_api_key
     def test_column_order_matches_constants(self, client):
         """Test that returned DataFrame columns match constants definition order."""
-        df = client.get_index_option(date="2024-12-27")
+        df = client.get_options_225_daily(date="2024-12-27")
 
         assert isinstance(df, pd.DataFrame)
         if not df.empty:

--- a/tests/test_integration/test_derivatives.py
+++ b/tests/test_integration/test_derivatives.py
@@ -1,0 +1,115 @@
+"""Integration tests for ClientV2 Derivatives endpoints.
+
+These tests require a valid J-Quants API key with Standard plan or higher.
+Run with: poetry run pytest -m integration tests/test_integration/test_derivatives.py
+
+"""
+
+import pandas as pd
+import pytest
+
+from jquants import constants_v2 as constants
+
+from .conftest import requires_api_key
+
+
+@pytest.mark.integration
+class TestDerivativesIntegration:
+    """Integration tests for Derivatives endpoints."""
+
+    @requires_api_key
+    def test_get_index_option(self, client):
+        """Test get_index_option returns valid DataFrame.
+
+        Note: The endpoint returns Nikkei 225 option data for the specified date.
+        """
+        df = client.get_index_option(date="2024-12-27")
+
+        assert isinstance(df, pd.DataFrame)
+        if not df.empty:
+            # Check column order matches constants
+            expected_cols = [
+                c for c in constants.DERIVATIVES_OPTIONS_225_COLUMNS if c in df.columns
+            ]
+            assert list(df.columns) == expected_cols
+
+            # Check date columns are datetime
+            for col in constants.DERIVATIVES_OPTIONS_225_DATE_COLUMNS:
+                if col in df.columns:
+                    assert pd.api.types.is_datetime64_any_dtype(df[col])
+
+            # Check sorted by Code
+            if len(df) > 1:
+                assert df["Code"].is_monotonic_increasing
+
+    @requires_api_key
+    def test_get_index_option_column_types(self, client):
+        """Test get_index_option returns correct column types."""
+        df = client.get_index_option(date="2024-12-27")
+
+        assert isinstance(df, pd.DataFrame)
+        if not df.empty:
+            # Check numeric columns are numeric (or NaN for empty values)
+            assert pd.api.types.is_numeric_dtype(df["Strike"])
+            assert pd.api.types.is_numeric_dtype(df["Vo"])
+            assert pd.api.types.is_numeric_dtype(df["OI"])
+
+            # Check CM column format (YYYY-MM)
+            if "CM" in df.columns:
+                sample_cm = (
+                    df["CM"].dropna().iloc[0] if not df["CM"].dropna().empty else None
+                )
+                if sample_cm:
+                    assert len(sample_cm) == 7  # "YYYY-MM"
+                    assert sample_cm[4] == "-"  # Separator
+
+    @requires_api_key
+    def test_get_index_option_range(self, client):
+        """Test get_index_option_range returns valid DataFrame."""
+        df = client.get_index_option_range(
+            start_dt="2024-12-26",
+            end_dt="2024-12-27",
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        if not df.empty:
+            # Check date columns are datetime
+            assert pd.api.types.is_datetime64_any_dtype(df["Date"])
+
+            # Check sorted by Code, Date
+            if len(df) > 1:
+                for i in range(len(df) - 1):
+                    code_i = df.iloc[i]["Code"]
+                    code_next = df.iloc[i + 1]["Code"]
+                    date_i = df.iloc[i]["Date"]
+                    date_next = df.iloc[i + 1]["Date"]
+                    assert (code_i < code_next) or (
+                        code_i == code_next and date_i <= date_next
+                    )
+
+    @requires_api_key
+    def test_get_index_option_empty_date(self, client):
+        """Test get_index_option with holiday returns empty DataFrame.
+
+        Note: API returns empty list on holidays, not 404 error.
+        """
+        # 2024-01-01 is New Year's Day (holiday)
+        df = client.get_index_option(date="2024-01-01")
+
+        assert isinstance(df, pd.DataFrame)
+        # Should return empty DataFrame (not error)
+        assert len(df) == 0
+        # Should still have column definitions
+        assert list(df.columns) == constants.DERIVATIVES_OPTIONS_225_COLUMNS
+
+    @requires_api_key
+    def test_column_order_matches_constants(self, client):
+        """Test that returned DataFrame columns match constants definition order."""
+        df = client.get_index_option(date="2024-12-27")
+
+        assert isinstance(df, pd.DataFrame)
+        if not df.empty:
+            expected_cols = [
+                c for c in constants.DERIVATIVES_OPTIONS_225_COLUMNS if c in df.columns
+            ]
+            assert list(df.columns) == expected_cols


### PR DESCRIPTION
## Summary

- 日経225オプション日足データの取得メソッドを実装
  - `get_options_225_daily(date)`: 指定日のオプションデータ取得
  - `get_options_225_daily_range(start_dt, end_dt)`: 日付範囲でのオプションデータ取得
- `constants_v2.py`: カラム定義追加 (DERIVATIVES_OPTIONS_225_COLUMNS 等)
- `_to_dataframe()`: `date_coerce_columns`, `numeric_columns` パラメータ追加

## Test plan

- [x] 単体テスト追加・パス (tests/test_client_v2_derivatives.py)
- [x] 結合テスト追加・パス (tests/test_integration/test_derivatives.py) - 5件パス
- [x] make lint パス
- [x] make test パス (318テスト、カバレッジ98%)
  - Note: integrationテストは `addopts = "-v -m 'not integration and not slow'"` により除外
  - 結合テストは `pytest -m integration` で別途実行・検証済み

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)