### PR TITLE
refactor: パラメータ排他チェックを共通化 (#37)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ get_*_range()     # Date range with ThreadPoolExecutor(max_workers=5)
 
 ## Code Style
 
-- Python 3.8+ (tomli for <3.11, tomllib for 3.11+)
+- Python 3.12+
 - Black formatter, isort
 - flake8 max-line-length=120
 - mypy type checking

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ api_key = "*****"
 
 ## 動作確認
 
-Google Colab および Python 3.11 で動作確認を行っています。
+Google Colab および Python 3.12 で動作確認を行っています。
 J-Quants API は有償版で継続開発されているため、本ライブラリも今後仕様が変更となる可能性があります。
 Python の EOL を迎えたバージョンはサポート対象外となります。
 Please note we only support Python supported versions. Unsupported versions (after EOL) are not supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 requests = "^2.32.0"
 types-requests = "^2.32.0"
 pandas = ">=2.1.0"


### PR DESCRIPTION
## Summary

- `_validate_date_param_combination` staticmethod を追加し、date/from_date/to_date の排他チェックロジックを共通化
- 7箇所のインラインチェックを共通メソッド呼び出しに置換
- `range_usage_hint` パラメータにより、メソッド固有のエラーメッセージ文言を維持（後方互換性）
- Python 3.12+ にプロジェクト設定を統一

## Test plan

- [x] `make lint` 通過
- [x] `make test` 361件全通過
- [x] 既存の排他チェックテストがリグレッションなし
- [x] 新規追加した12件のユニットテスト (VDP-001〜VDP-012) が通過

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `jquants/client_v2.py` | `_validate_date_param_combination` 追加、7箇所の置換 |
| `tests/test_client_v2.py` | 12件のユニットテスト追加 |
| `pyproject.toml` | `python = "^3.11"` → `"^3.12"` |
| `AGENTS.md` | `Python 3.8+` → `Python 3.12+` |
| `README.md` | `Python 3.11` → `Python 3.12` |

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)