### PR TITLE
refactor: 429リトライ制御の分離と高度化 (#44)

### DIFF
--- a/docs/design/v2/core.md
+++ b/docs/design/v2/core.md
@@ -45,12 +45,16 @@ api_key = "your_api_key"
 - **Allowed Methods:** `["HEAD", "GET", "OPTIONS"]` (POST is excluded to prevent side effects).
 
 ### Rate Limit Errors (429)
-- Handled via custom logic in `ClientV2._request()`.
+- Handled via custom logic in `ClientV2._request()`, using helper methods:
+  - `_parse_retry_after()`: Parses `Retry-After` header (RFC 7231 compliant).
+  - `_calculate_retry_wait()`: Pure function to determine wait seconds or retry abort.
 - **Parameters:**
   - `retry_on_429`: bool (Default: `True`)
-  - `retry_wait_seconds`: int (Default: `310`)
+  - `retry_wait_seconds`: int (Default: `310`) — fallback when `Retry-After` header is absent/invalid.
   - `retry_max_attempts`: int (Default: `3`)
-- **Wait Policy:** Uses `time.sleep(retry_wait_seconds)` between attempts.
+- **Wait Policy:**
+  - Respects `Retry-After` header if present and valid (including `Retry-After: 0` for immediate retry).
+  - Falls back to `retry_wait_seconds` if header is missing or invalid.
 
 ### Exceptions
 All custom exceptions inherit from `jquants.exceptions.JQuantsAPIError`.

--- a/docs/user_guide_v2.md
+++ b/docs/user_guide_v2.md
@@ -146,10 +146,11 @@ J-Quants API はプランごとにリクエスト上限が定められていま�
 万が一レート制限を超えた場合（HTTP 429エラー）、クライアントは自動的に待機してリトライします。
 
 - **デフォルト動作:** 310秒待機してリトライ（最大3回）
+- **Retry-After対応:** APIからの `Retry-After` ヘッダがある場合は、その値を優先して待機します
 - **設定変更:**
   ```python
   client = ClientV2(
-      retry_wait_seconds=60,  # 待機時間を60秒に変更
+      retry_wait_seconds=60,  # 待機時間を60秒に変更（Retry-Afterヘッダがない場合のフォールバック）
       retry_max_attempts=5    # 最大5回リトライ
   )
   ```

--- a/jquants/client_v2.py
+++ b/jquants/client_v2.py
@@ -462,7 +462,7 @@ class ClientV2:
             if response.status_code == 429:
                 wait_seconds = self._calculate_retry_wait(response, attempt)
                 if wait_seconds is None:
-                    # Retry not allowed → error handler (includes close)
+                    # Retry not allowed → error handler (close is called inside)
                     self._handle_error_response(response)
                 else:
                     # Retry allowed → close and wait

--- a/tests/test_integration/test_rate_limiter.py
+++ b/tests/test_integration/test_rate_limiter.py
@@ -328,6 +328,46 @@ class TestRequestPathIntegration:
                     # 429レスポンスがcloseされる（接続プール解放）
                     mock_response_429.close.assert_called_once()
 
+    def test_429_retry_uses_retry_after_header(self):
+        """429 + Retry-After ヘッダ → ヘッダ値で待機"""
+        from jquants import ClientV2
+
+        client = ClientV2(
+            api_key="test_api_key",
+            retry_on_429=True,
+            retry_wait_seconds=310,  # デフォルト値（使われないはず）
+            retry_max_attempts=3,
+        )
+
+        with patch.object(client, "_request_session") as mock_session_method:
+            mock_session = MagicMock()
+
+            # 1回目: 429 with Retry-After, 2回目: 200
+            mock_response_429 = MagicMock()
+            mock_response_429.ok = False
+            mock_response_429.status_code = 429
+            mock_response_429.text = '{"message": "Rate limit exceeded"}'
+            mock_response_429.json.return_value = {"message": "Rate limit exceeded"}
+            mock_response_429.headers = {"Retry-After": "5"}  # 5秒待機指示
+
+            mock_response_200 = MagicMock()
+            mock_response_200.ok = True
+            mock_response_200.status_code = 200
+
+            mock_session.request.side_effect = [mock_response_429, mock_response_200]
+            mock_session_method.return_value = mock_session
+
+            with patch.object(client._pacer, "wait", return_value=0.0):
+                with patch("time.sleep") as mock_sleep:
+                    response = client._request("GET", "/test")
+
+                    # 成功レスポンスが返る
+                    assert response.status_code == 200
+                    # Retry-Afterヘッダ値（5秒）で待機（デフォルト310秒ではない）
+                    mock_sleep.assert_called_once_with(5)
+                    # 429レスポンスがcloseされる
+                    mock_response_429.close.assert_called_once()
+
     def test_429_retry_disabled_raises_immediately(self):
         """429 + retry_on_429=False → 即例外"""
         from jquants import ClientV2
@@ -372,13 +412,19 @@ class TestRequestPathIntegration:
 
         with patch.object(client, "_request_session") as mock_session_method:
             mock_session = MagicMock()
-            mock_response = MagicMock()
-            mock_response.ok = False
-            mock_response.status_code = 429
-            mock_response.text = '{"message": "Rate limit exceeded"}'
-            mock_response.json.return_value = {"message": "Rate limit exceeded"}
-            mock_response.headers = {}  # No Retry-After header
-            mock_session.request.return_value = mock_response
+
+            # 各リクエストで異なるレスポンスを返す（close検証のため）
+            mock_responses = []
+            for _ in range(3):
+                resp = MagicMock()
+                resp.ok = False
+                resp.status_code = 429
+                resp.text = '{"message": "Rate limit exceeded"}'
+                resp.json.return_value = {"message": "Rate limit exceeded"}
+                resp.headers = {}  # No Retry-After header
+                mock_responses.append(resp)
+
+            mock_session.request.side_effect = mock_responses
             mock_session_method.return_value = mock_session
 
             with patch.object(client._pacer, "wait", return_value=0.0):
@@ -391,6 +437,12 @@ class TestRequestPathIntegration:
                     assert mock_sleep.call_count == 2
                     # sessionが3回呼ばれる（初回 + リトライ2回）
                     assert mock_session.request.call_count == 3
+                    # 全レスポンスがcloseされる（接続プール解放）
+                    mock_responses[0].close.assert_called_once()
+                    mock_responses[1].close.assert_called_once()
+                    mock_responses[
+                        2
+                    ].close.assert_called_once()  # 上限到達時も明示的にclose
 
     def test_connection_pool_uses_max_workers(self):
         """接続プールに_max_workersが反映される"""

--- a/tests/test_integration/test_rate_limiter.py
+++ b/tests/test_integration/test_rate_limiter.py
@@ -304,6 +304,7 @@ class TestRequestPathIntegration:
             mock_response_429.status_code = 429
             mock_response_429.text = '{"message": "Rate limit exceeded"}'
             mock_response_429.json.return_value = {"message": "Rate limit exceeded"}
+            mock_response_429.headers = {}  # No Retry-After header
 
             mock_response_200 = MagicMock()
             mock_response_200.ok = True
@@ -343,6 +344,7 @@ class TestRequestPathIntegration:
             mock_response.status_code = 429
             mock_response.text = '{"message": "Rate limit exceeded"}'
             mock_response.json.return_value = {"message": "Rate limit exceeded"}
+            mock_response.headers = {}  # No Retry-After header
             mock_session.request.return_value = mock_response
             mock_session_method.return_value = mock_session
 
@@ -375,6 +377,7 @@ class TestRequestPathIntegration:
             mock_response.status_code = 429
             mock_response.text = '{"message": "Rate limit exceeded"}'
             mock_response.json.return_value = {"message": "Rate limit exceeded"}
+            mock_response.headers = {}  # No Retry-After header
             mock_session.request.return_value = mock_response
             mock_session_method.return_value = mock_session
 


### PR DESCRIPTION
## Summary

- 429リトライ制御を純粋関数に分離し、テスタビリティを向上
- Retry-Afterヘッダ対応（RFC 7231準拠）
- リソース管理（response.close()）の明確化

## Changes

### 新規メソッド
- `_parse_retry_after(response)`: Retry-Afterヘッダ解析
- `_calculate_retry_wait(response, attempt)`: リトライ待機秒数計算（純粋関数）

### テスト追加（計14件）
- `TestParseRetryAfter`: PARSE-001〜005
- `TestCalculateRetryWait`: CALC-001〜008
- `test_429_retry_uses_retry_after_header`: Retry-Afterヘッダ結合テスト

### ドキュメント更新
- `docs/design/v2/core.md`: 内部ヘルパーと待機ポリシー
- `docs/user_guide_v2.md`: Retry-After対応の説明

## Test plan

- [x] 新規テスト（14件）PASSED
- [x] 既存テスト（374件）PASSED
- [x] 結合テスト（106件）PASSED
- [x] lint PASSED

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)